### PR TITLE
Fix for design guidelines preview section

### DIFF
--- a/src/cms/preview-templates/DesignGuidelinePagePreview.js
+++ b/src/cms/preview-templates/DesignGuidelinePagePreview.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { DesignGuidelinePostTemplate } from '../../templates/design-guideline-post/design-guideline-post'
 
-const ProductPagePreview = ({ entry, getAsset }) => {
+const ProductPagePreview = ({ entry, getAsset, widgetFor }) => {
   const entryBlurbs = entry.getIn(['data', 'intro', 'blurbs'])
   const blurbs = entryBlurbs ? entryBlurbs.toJS() : []
 
@@ -19,6 +19,7 @@ const ProductPagePreview = ({ entry, getAsset }) => {
       heading={entry.getIn(['data', 'heading'])}
       description={entry.getIn(['data', 'description'])}
       intro={{ blurbs }}
+      content={widgetFor('body')}
       main={{
         heading: entry.getIn(['data', 'main', 'heading']),
         description: entry.getIn(['data', 'main', 'description']),

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -5,8 +5,6 @@ import Flex from '../Flex';
 import Footer from '../LayoutFooter';
 import Header from '../LayoutHeader';
 
-import { media } from '../theme';
-
 class Template extends Component {
   render() {
     const { children, location } = this.props;

--- a/src/components/theme.js
+++ b/src/components/theme.js
@@ -97,7 +97,7 @@ const sharedStyles = {
       marginTop: 30,
       fontSize: 17,
       lineHeight: 1.7,
-      //maxWidth: '42em',
+      color: colors.subtle,
 
       '&:first-of-type': {
         marginTop: 15
@@ -178,11 +178,16 @@ const sharedStyles = {
       marginTop: 20
     },
 
+    '& table' : {
+      color: colors.subtle,
+    },
+
     '& ol, & ul': {
       marginTop: 20,
       fontSize: 16,
       color: colors.text,
       paddingLeft: 20,
+      color: colors.subtle,
 
       '& p, & p:first-of-type': {
         fontSize: 16,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -48,49 +48,49 @@ export default class IndexPage extends React.Component {
         </section>
         <section className="section whatsnew">
           <div className="whatsnew-wrapper">
-          <div className="container">
-            <div className="content">
-              <div className="whatsnew-header">
-                <h1 className="whatsnew-title">what's new</h1>
-                <div className="whatsnew-options">
-                  <div className="selected">web</div>
-                  <div>Mobile</div>
-                  <div>CUX</div>
-                  <div>AR/VR</div>
+            <div className="container">
+              <div className="content">
+                <div className="whatsnew-header">
+                  <h1 className="whatsnew-title">what's new</h1>
+                  <div className="whatsnew-options">
+                    <div className="selected">web</div>
+                    <div>Mobile</div>
+                    <div>CUX</div>
+                    <div>AR/VR</div>
+                  </div>
                 </div>
               </div>
-            </div>
-            <div className="new-lhs">
-              <div className="new-lhs-title">Learn about the latest updates and announcements to the Fiori Design System.</div>
-              <div className="new-lhs-option selected">all</div>
-              <div className="new-lhs-option">designer</div>
-              <div className="new-lhs-option">developer</div>
-            </div>
-            <div className="new-rhs">
-              {posts
-                .map(({ node: post }) => (
-                  <Link to={post.fields.slug}>
-                    <div
-                      className="content whatsnew-items"
-                      id={post.img}
-                      key={post.id}
-                    >
-                      <div className="newitem-item-content">
-                        <Img className="newitem-item-thumbnail" sizes={post.frontmatter.featuredImage.childImageSharp.sizes} />
-                        <p>
+              <div className="new-lhs">
+                <div className="new-lhs-title">Learn about the latest updates and announcements to the Fiori Design System.</div>
+                <div className="new-lhs-option selected">all</div>
+                <div className="new-lhs-option">designer</div>
+                <div className="new-lhs-option">developer</div>
+              </div>
+              <div className="new-rhs">
+                {posts
+                  .map(({ node: post }) => (
+                    <Link to={post.fields.slug} key={post.id}>
+                      <div
+                        className="content whatsnew-items"
+                        id={post.img}
+                        key={post.id}
+                      >
+                        <div className="newitem-item-content">
+                          <Img className="newitem-item-thumbnail" sizes={post.frontmatter.featuredImage.childImageSharp.sizes} />
+                          <p>
                             <span className="newitem-title">{post.frontmatter.title}</span>
-                        </p>
-                        <div className="newitem-details">
-                          {post.frontmatter.description}
+                          </p>
+                          <div className="newitem-details">
+                            {post.frontmatter.description}
+                          </div>
+                          <span className="newitem-more">Read More</span>
+                          <div className="newitem-date">{post.frontmatter.date}</div>
                         </div>
-                        <Link className="newitem-more" to={post.fields.slug}>Read More</Link>
-                        <div className="newitem-date">{post.frontmatter.date}</div>
                       </div>
-                    </div>
-                  </Link>
-                ))}
+                    </Link>
+                  ))}
               </div>
-              </div>
+            </div>
           </div>
         </section>
       </Layout>


### PR DESCRIPTION
- The content was missing in cms preview for design layout. 
- I have some trouble applying the styling in that area and I think it is something with the inline-styling and the iframe. If we use a css file it works correctly. Eg. the normalize one.
- Fix for console warnings. Please everybody keep your local branch synced with master especially when you create PRs with lots of changes things can be missed.
- Added some styling for the cms demo

![screenshot 2019-02-05 at 14 47 16](https://user-images.githubusercontent.com/44162302/52281262-aa70f800-2955-11e9-96fa-fd4fca3177b9.png)
![screenshot 2019-02-05 at 14 47 47](https://user-images.githubusercontent.com/44162302/52281266-acd35200-2955-11e9-8945-271a1a51937b.png)
