### PR TITLE
fix the hamburger menu

### DIFF
--- a/src/components/Hamburger/Menu/HamburgerMenu.js
+++ b/src/components/Hamburger/Menu/HamburgerMenu.js
@@ -15,7 +15,7 @@ class HamburgerMenu extends React.Component {
         css={{
           display: 'block',
           height: 0,
-          position: 'absolute',
+          position: 'fixed',
           top: 60,
           zIndex: 1000,
           width: '100%',
@@ -40,7 +40,6 @@ class HamburgerMenu extends React.Component {
               <li
                 key={defaultItem[0].id}
                 css={{
-                  padding: 20,
                   borderTopColor: colors.gray_200,
                   borderTopStyle: 'solid',
                   borderTopWidth: 1

--- a/src/components/Hamburger/Menu/InternalMenuLink.js
+++ b/src/components/Hamburger/Menu/InternalMenuLink.js
@@ -10,6 +10,10 @@ const InternalMenuLink = ({ children, target, to }) => (
       color: colors.gray_600,
       fontSize: 18,
       fontWeight: 'normal',
+      width: '100%',
+      height: '100%',
+      display: 'inline-block',
+      padding: 20,
       ':hover': {
         color: colors.gray_700
       }

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -81,9 +81,11 @@ class Layout extends React.Component {
     this.setState({ menuToggle: toggle }, () => {
       if (!this.state.menuToggle) {
         document.body.style.overflow = 'auto';
+        document.body.style.position = 'inherit';
       } else {
         window.scrollTo(0, 0);
         document.body.style.overflow = 'hidden';
+        document.body.style.position = 'fixed';
       }
     });
   }


### PR DESCRIPTION
fix the hamburger menu,
- link on menu full width
- no scroll anymore

If you need to access your local dev on your phone just start gatsby with:

`gatsby develop -H 0.0.0.0`

then on your phone access it via the full hostname:
````
$ hostname
C02TC0VWGTF1
````
on a corporate phone then access on your browser via:
'C02TC0VWGTF1.dhcp.dub.sap.corp'
