### PR TITLE
add trailing slashes for guideline posts to prevent onetime reload

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -40,7 +40,7 @@ exports.createPages = ({ actions, graphql }) => {
       const version = edge.node.frontmatter.version;
       if (edge.node.frontmatter.templateKey.includes('-guideline-post')){
         createPage({
-          path: `/designguideline/${String(edge.node.frontmatter.version)}/${String(edge.node.frontmatter.title)}`,
+          path: `/designguideline/${String(edge.node.frontmatter.version)}/${String(edge.node.frontmatter.title)}/`,
           tags: edge.node.frontmatter.tags,
           component: path.resolve(
             `src/templates/design-guideline-post/design-guideline-post.js`
@@ -99,7 +99,7 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
 
   if (node.internal.type === `MarkdownRemark`) {
     if (node.frontmatter.templateKey.includes('-guideline-post')){
-      const value = `/designguideline/${String(node.frontmatter.version)}/${String(node.frontmatter.title)}`;
+      const value = `/designguideline/${String(node.frontmatter.version)}/${String(node.frontmatter.title)}/`;
       createNodeField({
         name: `slug`,
         node,


### PR DESCRIPTION
issue: https://github.wdf.sap.corp/gd/FioriExperience/issues/193
belongs to: https://github.com/devinea/mvx19-cms/pull/106

adds a trailing `/` to the guideline posts so that the first click on the ToC doesn't reload the page