### PR TITLE
Adding scrolling capability to LHS Nav when needed

### DIFF
--- a/src/components/LeftNav/LeftNav.js
+++ b/src/components/LeftNav/LeftNav.js
@@ -134,7 +134,7 @@ class LeftNav extends React.Component {
       if (!menuHover || !menuContainer) {
         return;
       }
-      const hoverPosition = element.getBoundingClientRect().y - menuContainer.getBoundingClientRect().y;
+      const hoverPosition = element.getBoundingClientRect().y - menuContainer.getBoundingClientRect().y + menuContainer.scrollTop;
       menuHover.style.opacity = 1;
       menuHover.style.top = hoverPosition + 'px';
       this.isOverElement = true;
@@ -281,7 +281,8 @@ class LeftNav extends React.Component {
                 position: 'relative',
                 float: 'left',
                 width: '100%',
-                overflow: 'hidden',
+                height: 'calc(100% - 155px)',
+                overflowX: 'auto',
                 [media.lessThan('large')]: {
                   maxHeight: 0,
                   transition: 'max-height 0.3s ease-in-out',

--- a/src/components/LeftNav/LeftNavLink.js
+++ b/src/components/LeftNav/LeftNavLink.js
@@ -112,7 +112,7 @@ class LeftNavLink extends React.Component {
                                 content: '""',
                                 border: 0,
                                 top: 15,
-                                right: 10,
+                                right: 20,
                                 width: 14,
                                 cursor: 'pointer',
                                 fontFamily: 'SAP-icons',


### PR DESCRIPTION
LHS nav should now scroll when menu items are expanded and scrolling is required.
Note that the whole page still re-renders after each navigation, so that the user is brought back to the top of the scroll after a page change.  Obviously this is not desired.  We should look at adding `gatsby-plugin-layout` to ensure that the top and LHS nav is not re-rendered on navigation.