### PR TITLE
Add Redux for LHS navigation.

### DIFF
--- a/src/pages/guideline/android/index.js
+++ b/src/pages/guideline/android/index.js
@@ -1,14 +1,22 @@
 import React from 'react';
 
 import Flex from '../../../components/Flex';
-import Layout from '../../../components/Layout';
 import { media } from '../../../components/theme';
 
 import LeftNav from '../../../components/LeftNav';
 import designImg from '../../../img/design.png';
 import { graphql } from "gatsby";
+import { setLhsItems } from '../../../../src/state/app.js';
+import { connect } from 'react-redux';
 
-export default class DesignGuidelineIndexPage extends React.Component {
+class DesignGuidelineIndexPage extends React.Component {
+
+  componentDidMount = () => {
+    // Update the LHS Navigation.
+    const { data, dispatch } = this.props;
+    dispatch(setLhsItems(data.leftNav));
+  }
+
   render() {
     const { data, location } = this.props;
 
@@ -23,7 +31,7 @@ export default class DesignGuidelineIndexPage extends React.Component {
             width: '100%',
           }}
         >
-          <LeftNav data={(data.leftNav)}/>
+          <LeftNav/>
           <div
             css={{
               width: '100%',
@@ -47,6 +55,8 @@ export default class DesignGuidelineIndexPage extends React.Component {
     );
   }
 }
+
+export default connect()(DesignGuidelineIndexPage);
 
 export const pageQuery = graphql`
     query AndroidGuidelinePageQuery($curVersion: String!) {

--- a/src/pages/guideline/cux/index.js
+++ b/src/pages/guideline/cux/index.js
@@ -1,14 +1,22 @@
 import React from 'react';
 
 import Flex from '../../../components/Flex';
-import Layout from '../../../components/Layout';
 import { media } from '../../../components/theme';
 
 import LeftNav from '../../../components/LeftNav';
 import designImg from '../../../img/design.png';
 import { graphql } from "gatsby";
+import { setLhsItems } from '../../../../src/state/app.js';
+import { connect } from 'react-redux';
 
-export default class DesignGuidelineIndexPage extends React.Component {
+class DesignGuidelineIndexPage extends React.Component {
+
+  componentDidMount = () => {
+    // Update the LHS Navigation.
+    const { data, dispatch } = this.props;
+    dispatch(setLhsItems(data.leftNav));
+  }
+
   render() {
     const { data, location } = this.props;
 
@@ -23,7 +31,7 @@ export default class DesignGuidelineIndexPage extends React.Component {
             width: '100%',
           }}
         >
-          <LeftNav data={(data.leftNav)}/>
+          <LeftNav/>
           <div
             css={{
               width: '100%',
@@ -47,6 +55,8 @@ export default class DesignGuidelineIndexPage extends React.Component {
     );
   }
 }
+
+export default connect()(DesignGuidelineIndexPage);
 
 export const pageQuery = graphql`
     query CuxGuidelinePageQuery($curVersion: String!) {

--- a/src/pages/guideline/ios/index.js
+++ b/src/pages/guideline/ios/index.js
@@ -11,6 +11,7 @@ import Panel from '../../../components/Panel';
 import Dropdown from '../../../components/Dropdown';
 import SeeAllButton from '../../../components/SeeAllButton';
 import { ReactReduxContext, connect } from 'react-redux';
+import { setLhsItems } from '../../../../src/state/app.js';
 
 const getWidths = () => {
   return {
@@ -53,6 +54,10 @@ class GuidelineIosIndexPage extends React.Component {
   }
 
   componentDidMount = () => {
+    // Update the LHS Navigation.
+    const { data, dispatch } = this.props;
+    dispatch(setLhsItems(data.leftNav));
+
     if (!window.matchMedia) return;
     const medium = media.getSize('medium');
     this.mediaQueryListener = window.matchMedia(`(max-width: ${medium.max}px)`);
@@ -88,7 +93,7 @@ class GuidelineIosIndexPage extends React.Component {
           css={{
             width: '100%',
           }}>
-          <LeftNav data={data.leftNav.edges[0]} />
+          <LeftNav/>
           <div css={{
             width: '100%',
             display: 'flex',

--- a/src/pages/guideline/web/index.js
+++ b/src/pages/guideline/web/index.js
@@ -1,14 +1,22 @@
 import React from 'react';
 
 import Flex from '../../../components/Flex';
-import Layout from '../../../components/Layout';
 import { media } from '../../../components/theme';
 
 import LeftNav from '../../../components/LeftNav';
 import designImg from '../../../img/design.png';
 import { graphql } from "gatsby";
+import { setLhsItems } from '../../../../src/state/app.js';
+import { connect } from 'react-redux';
 
-export default class DesignGuidelineIndexPage extends React.Component {
+class DesignGuidelineIndexPage extends React.Component {
+
+  componentDidMount = () => {
+    // Update the LHS Navigation.
+    const { data, dispatch } = this.props;
+    dispatch(setLhsItems(data.leftNav));
+  }
+
   render() {
     const { data, location } = this.props;
 
@@ -23,7 +31,7 @@ export default class DesignGuidelineIndexPage extends React.Component {
             width: '100%',
           }}
         >
-          <LeftNav data={(data.leftNav)}/>
+          <LeftNav/>
           <div
             css={{
               width: '100%',
@@ -47,6 +55,8 @@ export default class DesignGuidelineIndexPage extends React.Component {
     );
   }
 }
+
+export default connect()(DesignGuidelineIndexPage);
 
 export const pageQuery = graphql`
     query WebGuidelinePageQuery($curVersion: String!) {

--- a/src/state/app.js
+++ b/src/state/app.js
@@ -4,7 +4,8 @@ const initialState = {
   breakPoint: {
     breakpointName: 'default',
     breakpointSize: null
-  }
+  },
+  lhsItems: []
 };
 
 const TOGGLE_HAMBURGER_MENU = 'TOGGLE_HAMBURGER_MENU';
@@ -24,6 +25,13 @@ export const setActiveBreakpoint = value => ({
   payload: value
 });
 
+const LHS_MENU_ITEMS = 'LHS_MENU_ITEMS';
+export const setLhsItems = value => ({
+    type: LHS_MENU_ITEMS,
+    payload: value
+});
+
+
 export default (state = initialState, action) => {
   const { type, payload } = action;
   switch (type) {
@@ -33,6 +41,8 @@ export default (state = initialState, action) => {
       return { ...state, valueForPanels: payload };
     case SET_ACTIVE_BREAKPOINT:
       return { ...state, breakPoint: payload };
+    case LHS_MENU_ITEMS:
+      return {...state, lhsItems: payload };
     default:
       return state;
   }

--- a/src/templates/web-guideline-post/web-guideline-post.js
+++ b/src/templates/web-guideline-post/web-guideline-post.js
@@ -6,12 +6,13 @@ import { graphql, Link } from 'gatsby';
 
 import Filter from '../../components/Filter/Filter.js';
 import Flex from '../../components/Flex';
-import Layout from '../../components/Layout';
 
 import { sharedStyles, media } from '../../components/theme';
 
 import Content, { HTMLContent } from '../../components/Content';
 import LeftNav from '../../components/LeftNav';
+import { setLhsItems } from '../../../src/state/app.js';
+import { connect } from 'react-redux';
 
 
 export const DesignGuidelinePostTemplate = ({
@@ -66,11 +67,18 @@ DesignGuidelinePostTemplate.propTypes = {
 };
 
 
-const WebGuidelinePost = ({ data, location, pageContext }) => {
-  const { markdownRemark: post, guidelineVersions} = data;
-  let navOpen = true;
+class WebGuidelinePost extends React.Component {
 
-  return (
+  componentDidMount = () => {
+    // Update the LHS Navigation.
+    const { data, dispatch } = this.props;
+    dispatch(setLhsItems(data.leftNav));
+  }
+
+  render() {
+    const { data, location, pageContext } = this.props;
+    const { markdownRemark: post, guidelineVersions} = data;
+    return (
       <Flex
         direction='row'
         shrink='0'
@@ -82,7 +90,7 @@ const WebGuidelinePost = ({ data, location, pageContext }) => {
           height: '100%'
         }}
       >
-        <LeftNav data={data.leftNav.edges[0]}/>
+        <LeftNav/>
         <div id="design-guideline-div"
           css={{
             width: 828,
@@ -114,7 +122,8 @@ const WebGuidelinePost = ({ data, location, pageContext }) => {
           />
         </div>
       </Flex>
-  );
+    )
+  };
 };
 
 WebGuidelinePost.propTypes = {
@@ -126,7 +135,7 @@ WebGuidelinePost.propTypes = {
   })
 };
 
-export default WebGuidelinePost;
+export default connect()(WebGuidelinePost);
 
 export const pageQuery = graphql`
   query DesignGuidelinePostByID($id: String!, $version: String!, $templateKey: String!) {


### PR DESCRIPTION
Updating the LHS nav to use Redux for the storing and reading the navigation menu. 

Note: A further PR will be required to move the LeftNav component into the layout component, where it will no longer be re-rendered on navigation. This first PR is to ensure there is the correct communication between the LeftNav and associated pages.